### PR TITLE
Set process exit code to 0 on success, 1 on failure

### DIFF
--- a/src/ScmBackup.Tests/ErrorHandlingScmBackupTests.cs
+++ b/src/ScmBackup.Tests/ErrorHandlingScmBackupTests.cs
@@ -6,8 +6,7 @@ namespace ScmBackup.Tests
 {
     public class ErrorHandlingScmBackupTests
     {
-        [Fact]
-        public void LogsWhenExceptionIsThrown()
+        static (FakeLogger FakeLogger, ErrorHandlingScmBackup ErrorHandlingScmBackup) BuildFakeScmBackup()
         {
             var ex = new Exception("!!!");
             var subBackup = new FakeScmBackup();
@@ -21,6 +20,14 @@ namespace ScmBackup.Tests
             var logger = new FakeLogger();
 
             var backup = new ErrorHandlingScmBackup(subBackup, logger, context);
+            return (logger, backup);
+        }
+
+        [Fact]
+        public void LogsWhenExceptionIsThrown()
+        {
+            var (logger, backup) = BuildFakeScmBackup();
+
             backup.Run();
 
             Assert.True(logger.LoggedSomething);

--- a/src/ScmBackup.Tests/ErrorHandlingScmBackupTests.cs
+++ b/src/ScmBackup.Tests/ErrorHandlingScmBackupTests.cs
@@ -35,5 +35,15 @@ namespace ScmBackup.Tests
             // we can't check whether the last exception is the exception from above,
             // because there are more logging outputs after the exception.
         }
+
+        [Fact]
+        public void ReturnsFalseWhenExceptionIsThrown()
+        {
+            var (_, backup) = BuildFakeScmBackup();
+
+            var result = backup.Run();
+
+            Assert.False(result);
+        }
     }
 }

--- a/src/ScmBackup.Tests/FakeScmBackup.cs
+++ b/src/ScmBackup.Tests/FakeScmBackup.cs
@@ -5,13 +5,16 @@ namespace ScmBackup.Tests
     public class FakeScmBackup : IScmBackup
     {
         public Exception ToThrow { get; set; }
+        public bool ToReturn { get; set; } = true;
 
-        public void Run()
+        public bool Run()
         {
             if (this.ToThrow != null)
             {
                 throw this.ToThrow;
             }
+
+            return ToReturn;
         }
     }
 }

--- a/src/ScmBackup.Tests/LogMailingScmBackupTests.cs
+++ b/src/ScmBackup.Tests/LogMailingScmBackupTests.cs
@@ -5,9 +5,10 @@ namespace ScmBackup.Tests
 {
     public class LogMailingScmBackupTests
     {
-        static (FakeEmailSender mail, LogMailingScmBackup sut) BuildFakeLogMailingScmBackup()
+        static (FakeEmailSender mail, LogMailingScmBackup sut) BuildFakeLogMailingScmBackup(bool innerReturnValue)
         {
             var subBackup = new FakeScmBackup();
+            subBackup.ToReturn = innerReturnValue;
 
             var messages = new LogMessages();
             messages.AddMessage("1");
@@ -22,7 +23,7 @@ namespace ScmBackup.Tests
         [Fact]
         public void RunSendsMail()
         {
-            var (mail, sut) = BuildFakeLogMailingScmBackup();
+            var (mail, sut) = BuildFakeLogMailingScmBackup(true);
 
             sut.Run();
 
@@ -30,6 +31,18 @@ namespace ScmBackup.Tests
             Assert.NotNull(mail.LastBody);
             Assert.Contains("1", mail.LastBody);
             Assert.Contains("2", mail.LastBody);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RunReturnsValueFromInnerExecution(bool innerReturnValue)
+        {
+            var (mail, sut) = BuildFakeLogMailingScmBackup(innerReturnValue);
+
+            var result = sut.Run();
+
+            Assert.Equal(result, innerReturnValue);
         }
     }
 }

--- a/src/ScmBackup.Tests/LogMailingScmBackupTests.cs
+++ b/src/ScmBackup.Tests/LogMailingScmBackupTests.cs
@@ -5,8 +5,7 @@ namespace ScmBackup.Tests
 {
     public class LogMailingScmBackupTests
     {
-        [Fact]
-        public void RunSendsMail()
+        static (FakeEmailSender mail, LogMailingScmBackup sut) BuildFakeLogMailingScmBackup()
         {
             var subBackup = new FakeScmBackup();
 
@@ -17,6 +16,14 @@ namespace ScmBackup.Tests
             var mail = new FakeEmailSender();
 
             var sut = new LogMailingScmBackup(subBackup, messages, mail);
+            return (mail, sut);
+        }
+
+        [Fact]
+        public void RunSendsMail()
+        {
+            var (mail, sut) = BuildFakeLogMailingScmBackup();
+
             sut.Run();
 
             Assert.NotNull(mail.LastSubject);

--- a/src/ScmBackup/ErrorHandlingScmBackup.cs
+++ b/src/ScmBackup/ErrorHandlingScmBackup.cs
@@ -27,14 +27,14 @@ namespace ScmBackup
             this.WaitSecondsOnError = 5;
         }
 
-        public void Run()
+        public bool Run()
         {
             string className = this.GetType().Name;
 
             try
             {
                 this.logger.Log(ErrorLevel.Debug, Resource.StartingBackup, className);
-                this.backup.Run();
+                return this.backup.Run();
             }
             catch (Exception ex)
             {
@@ -52,6 +52,8 @@ namespace ScmBackup
                 this.logger.Log(ErrorLevel.Error, Resource.BackupFailed);
                 this.logger.Log(ErrorLevel.Error, Resource.EndSeconds, seconds);
                 Task.Delay(TimeSpan.FromSeconds(seconds)).Wait();
+
+                return false;
             }
         }
     }

--- a/src/ScmBackup/ErrorHandlingScmBackup.cs
+++ b/src/ScmBackup/ErrorHandlingScmBackup.cs
@@ -29,22 +29,17 @@ namespace ScmBackup
 
         public void Run()
         {
-            bool ok = false;
             string className = this.GetType().Name;
 
             try
             {
                 this.logger.Log(ErrorLevel.Debug, Resource.StartingBackup, className);
                 this.backup.Run();
-                ok = true;
             }
             catch (Exception ex)
             {
                 this.logger.Log(ErrorLevel.Error, ex.Message);
-            }
 
-            if (!ok)
-            {
                 // Wait as many seconds as defined in the config.
                 // If we don't have the config value because the exception was thrown while reading the config, use the default value defined in this class
                 int seconds = this.WaitSecondsOnError;

--- a/src/ScmBackup/IScmBackup.cs
+++ b/src/ScmBackup/IScmBackup.cs
@@ -2,6 +2,6 @@
 {
     internal interface IScmBackup
     {
-        void Run();
+        bool Run();
     }
 }

--- a/src/ScmBackup/LogMailingScmBackup.cs
+++ b/src/ScmBackup/LogMailingScmBackup.cs
@@ -21,14 +21,16 @@ namespace ScmBackup
             this.mail = mail;
         }
 
-        public void Run()
+        public bool Run()
         {
-            this.backup.Run();
+            var result = this.backup.Run();
 
             string subject = string.Format(Resource.LogMailSubject, DateTime.Now.ToString("dd MMM HH:mm:ss"));
             string body = string.Join(Environment.NewLine, this.messages.GetMessages().ToArray());
 
             this.mail.Send(subject, body);
+
+            return result;
         }
     }
 }

--- a/src/ScmBackup/LoggingScmBackup.cs
+++ b/src/ScmBackup/LoggingScmBackup.cs
@@ -13,17 +13,19 @@
             this.logger = logger;
         }
 
-        public void Run()
+        public bool Run()
         {
             logger.Log(ErrorLevel.Info, this.context.AppTitle);
             logger.Log(ErrorLevel.Info, Resource.AppWebsite);
 
             // TODO: log more stuff (operating system, configuration...)
 
-            this.backup.Run();
+            var result = this.backup.Run();
 
             logger.Log(ErrorLevel.Info, Resource.BackupFinished);
             logger.Log(ErrorLevel.Info, string.Format(Resource.BackupFinishedDirectory, this.context.Config.LocalFolder));
+
+            return result;
         }
     }
 }

--- a/src/ScmBackup/Program.cs
+++ b/src/ScmBackup/Program.cs
@@ -4,10 +4,11 @@ namespace ScmBackup
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
             var container = Bootstrapper.BuildContainer();            
-            container.GetInstance<IScmBackup>().Run();
+            var success = container.GetInstance<IScmBackup>().Run();
+            return success ? 0 : 1;
         }
     }
 }

--- a/src/ScmBackup/ScmBackup.cs
+++ b/src/ScmBackup/ScmBackup.cs
@@ -21,7 +21,7 @@ namespace ScmBackup
             this.configBackupMaker = configBackupMaker;
         }
 
-        public void Run()
+        public bool Run()
         {
             this.configBackupMaker.BackupConfigs();
 
@@ -36,6 +36,8 @@ namespace ScmBackup
             {
                 this.backupMaker.Backup(source, repos.GetReposForSource(source));
             }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
As discussed in #53, we want to return an exit code from the process so that scripts know if the backup completed successfully or not.

Hopefully this lays the groundwork for #47 as well.

Note that I've broken the commits into - hopefully - understandable chunks.

In addition to running the automated tests that don't require authentication, I have manually tested the return code on Debian Linux. I have no reason to believe it wouldn't work on Windows as well.