### PR TITLE
add support for bitbucket Api tokens

### DIFF
--- a/src/ScmBackup/Configuration/ConfigSource.cs
+++ b/src/ScmBackup/Configuration/ConfigSource.cs
@@ -30,11 +30,17 @@ namespace ScmBackup.Configuration
         public string Name { get; set; }
 
         /// <summary>
+        /// user name for api authentication, used only for Bitbucket
+        /// See issue 84
+        /// </summary>
+        public string ApiAuthName { get; set; }
+        
+        /// <summary>
         /// user name for authentication
         /// (can be a different than the user whose repositories are backed up)
         /// </summary>
         public string AuthName { get; set; }
-
+        
         /// <summary>
         /// list of repository names which should be ignored
         /// </summary>

--- a/src/ScmBackup/Hosters/Bitbucket/BitbucketApi.cs
+++ b/src/ScmBackup/Hosters/Bitbucket/BitbucketApi.cs
@@ -28,7 +28,9 @@ namespace ScmBackup.Hosters.Bitbucket
 
             if (source.IsAuthenticated)
             {
-                request.AddBasicAuthHeader(source.AuthName, source.Password);
+                // The new Bitbucket authentication method uses a different user for API authentication. See issue 84.
+                var authName = string.IsNullOrWhiteSpace(source.ApiAuthName) ? source.AuthName : source.ApiAuthName;
+                request.AddBasicAuthHeader(authName, source.Password);
             }
 
             string url = "/2.0/repositories/" + source.Name;


### PR DESCRIPTION
I added support for Bitbucket API tokens. As the new authentication method requires two distinct usernames, I added the configuration property `apiAuthName`.


```yaml
- title:  github_singleuser
    hoster: github
    type: user
    name: scm-backup-testuser
    apiAuthName: email@example.com
    authName: username
```